### PR TITLE
Fix: Initialize upload_events table in db initializer

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -94,6 +94,22 @@ def db_init() -> None:
         );
         """
     )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS upload_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            token TEXT,
+            uploadedat TEXT DEFAULT CURRENT_TIMESTAMP,
+            ip TEXT,
+            useragent TEXT,
+            fingerprint TEXT,
+            filename TEXT,
+            size INTEGER,
+            checksum TEXT,
+            immichassetid TEXT
+        );
+        """
+    )
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
## Problem
The `upload_events` table was not being created during database initialization in `db_init()`. Instead, it was only created inline during the first upload operation. This caused a `sqlite3.OperationalError: no such table: upload_events` when attempting to delete invites via `api_invites_delete` if no uploads had occurred yet.

**Error:**
```
2025-10-24 23:34:35,901 ERROR immich_drop: Bulk delete failed: no such table: upload_events
sqlite3.OperationalError: no such table: upload_events
```

## Solution
Added `upload_events` table creation to the `db_init()` function to ensure it exists from application startup, matching the pattern used for the `uploads` table.

## Changes
- Added `CREATE TABLE IF NOT EXISTS upload_events` statement to `db_init()`
- Ensures table schema matches the column names used in INSERT statements throughout the codebase