### PR TITLE
Allow chunk size in fractions of a megabyte

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -23,7 +23,7 @@ class Settings:
     session_secret: str = ""
     log_level: str = "INFO"
     chunked_uploads_enabled: bool = False
-    chunk_size_mb: int = 95
+    chunk_size_mb: float = 95
 
     @property
     def normalized_base_url(self) -> str:
@@ -55,7 +55,7 @@ def load_settings() -> Settings:
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     chunked_uploads_enabled = as_bool(os.getenv("CHUNKED_UPLOADS_ENABLED", "false"), False)
     try:
-        chunk_size_mb = int(os.getenv("CHUNK_SIZE_MB", "95"))
+        chunk_size_mb = float(os.getenv("CHUNK_SIZE_MB", "95"))
     except ValueError:
         chunk_size_mb = 95
     return Settings(

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -72,7 +72,7 @@ initDarkMode();
       const j = await r.json();
       if (j && typeof j === 'object') {
         CFG.chunked_uploads_enabled = !!j.chunked_uploads_enabled;
-        const n = parseInt(j.chunk_size_mb, 10);
+        const n = parseFloat(j.chunk_size_mb, 10);
         if (!Number.isNaN(n) && n > 0) CFG.chunk_size_mb = n;
       }
     }
@@ -238,7 +238,7 @@ async function uploadWhole(next){
 }
 
 async function uploadChunked(next){
-  const chunkBytes = Math.max(1, CFG.chunk_size_mb|0) * 1024 * 1024;
+  const chunkBytes = Math.max(1024, CFG.chunk_size_mb * 1024 * 1024);
   const total = Math.ceil(next.file.size / chunkBytes) || 1;
   // init
   try {


### PR DESCRIPTION
Nginx' default max body size is 1m. I don't know if that is 100000 instead of 1024*1024 or what is going on, but it does not work with immich-drop chunk size "1". So I think it makes sense to allow fractions of a megabyte as chunk size so that immich-drop can work behind an nginx reverse proxy with default settings.