### PR TITLE
Make CHUNK_ROOT configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,4 +28,5 @@ LOG_LEVEL=DEBUG
 # Recommended chunk size for Cloudflare Tunnel is <= 95MB.
 CHUNKED_UPLOADS_ENABLED=false
 CHUNK_SIZE_MB=95
+CHUNK_ROOT=/data/chunks
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Roadmap highlight
 
 - Enable chunked uploads by setting `CHUNKED_UPLOADS_ENABLED=true`.
 - Configure chunk size with `CHUNK_SIZE_MB` (default: `95`). The client only uses chunked mode for files larger than this.
+- Configure chunk temp storage with `CHUNK_ROOT` (default: `/data/chunks`).
 - Intended to bypass upstream limits (e.g., 100MB) while preserving duplicate checks, EXIF timestamps, album add, and per‑item progress via WebSocket.
 
 ---
@@ -236,6 +237,7 @@ LOG_LEVEL=DEBUG
 # Chunked uploads (optional)
 CHUNKED_UPLOADS_ENABLED=true
 CHUNK_SIZE_MB=95
+CHUNK_ROOT=/data/chunks
 
 ```
 

--- a/app/app.py
+++ b/app/app.py
@@ -60,7 +60,7 @@ FRONTEND_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "fronten
 app.mount("/static", StaticFiles(directory=FRONTEND_DIR), name="static")
 
 # Chunk upload storage
-CHUNK_ROOT = "/data/chunks"
+CHUNK_ROOT = SETTINGS.chunk_root
 try:
     os.makedirs(CHUNK_ROOT, exist_ok=True)
 except Exception:

--- a/app/config.py
+++ b/app/config.py
@@ -24,6 +24,7 @@ class Settings:
     log_level: str = "INFO"
     chunked_uploads_enabled: bool = False
     chunk_size_mb: int = 95
+    chunk_root: str = "/data/chunks"
 
     @property
     def normalized_base_url(self) -> str:
@@ -58,6 +59,7 @@ def load_settings() -> Settings:
         chunk_size_mb = int(os.getenv("CHUNK_SIZE_MB", "95"))
     except ValueError:
         chunk_size_mb = 95
+    chunk_root = os.getenv("CHUNK_ROOT", "/data/chunks")
     return Settings(
         immich_base_url=base,
         immich_api_key=api_key,
@@ -70,4 +72,5 @@ def load_settings() -> Settings:
         log_level=log_level,
         chunked_uploads_enabled=chunked_uploads_enabled,
         chunk_size_mb=chunk_size_mb,
+        chunk_root=chunk_root,
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       # Chunked uploads to bypass 100MB limits (e.g., Cloudflare Tunnel)
       CHUNKED_UPLOADS_ENABLED: true
       CHUNK_SIZE_MB: 95
+      CHUNK_ROOT: /data/chunks
 
 
     volumes:

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -18,6 +18,7 @@ services:
       # Chunked uploads to bypass 100MB limits (e.g., Cloudflare Tunnel)
       CHUNKED_UPLOADS_ENABLED: true
       CHUNK_SIZE_MB: 95
+      CHUNK_ROOT: /data/chunks
 
 
     volumes:


### PR DESCRIPTION
Hardcoding this to `/data/chunk` is fine in Docker, but for testing locally, I needed to use a different path.