### PR TITLE
fix: date format for immich v3

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -477,8 +477,8 @@ async def api_upload(
     exif_created, exif_modified = read_exif_datetimes(raw)
     created_at = exif_created or (datetime.fromtimestamp(last_modified / 1000) if last_modified else datetime.utcnow())
     modified_at = exif_modified or created_at
-    created_iso = created_at.isoformat()
-    modified_iso = modified_at.isoformat()
+    created_iso = created_at.isoformat() if created_at.tzinfo else f"{created_at.isoformat()}Z"
+    modified_iso = modified_at.isoformat() if modified_at.tzinfo else f"{modified_at.isoformat()}Z"
 
     device_asset_id = f"{file.filename}-{last_modified or 0}-{size}"
 
@@ -857,8 +857,8 @@ async def api_upload_chunk_complete(request: Request) -> JSONResponse:
     exif_created, exif_modified = read_exif_datetimes(raw)
     created_at = exif_created or (datetime.fromtimestamp(last_modified / 1000) if last_modified else datetime.utcnow())
     modified_at = exif_modified or created_at
-    created_iso = created_at.isoformat()
-    modified_iso = modified_at.isoformat()
+    created_iso = created_at.isoformat() if created_at.tzinfo else f"{created_at.isoformat()}Z"
+    modified_iso = modified_at.isoformat() if modified_at.tzinfo else f"{modified_at.isoformat()}Z"
     device_asset_id = f"{file_like_name}-{last_modified or 0}-{file_size}"
 
     # Local duplicate checks


### PR DESCRIPTION
Immich v3 added a breaking change to enforce stricter date strings with https://github.com/immich-app/immich/pull/26597. `immich-drop` does not always include a timezone in the date strings sent to the immich API. 

As a result, when uploading an image, `immich-server` refuses to accept the request:
```json
{
  "statusCode": 400,
  "message": "Validation failed",
  "errors": [
    {
      "origin": "string",
      "code": "invalid_format",
      "format": "datetime",
      "pattern": "/^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$/",
      "path": ["fileCreatedAt"],
      "message": "Invalid input: expected ISO 8601 datetime string, received string"
    },
    {
      "origin": "string",
      "code": "invalid_format",
      "format": "datetime",
      "pattern": "/^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$/",
      "path": ["fileModifiedAt"],
      "message": "Invalid input: expected ISO 8601 datetime string, received string"
    }
  ]
}
```

This PR fixes the issue by forcing a `Z` at the end of the date string when no timezone is set.