### PR TITLE
fix: require invite preflight when public uploader is disabled

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -459,6 +459,124 @@ async def ws_endpoint(ws: WebSocket) -> None:
     except WebSocketDisconnect:
         await hub.disconnect(session_id, ws)
 
+# ---------- Invite preflight gating ----------
+#
+# Public-deployment hardening: when PUBLIC_UPLOAD_PAGE_ENABLED is false the upload
+# API must reject requests that lack a valid, active invite *before* any file body
+# is read into memory or written/assembled on disk. The preflight is deliberately
+# read-only: it must NOT claim an invite or increment usage — those semantics stay
+# in the real upload path so behaviour is unchanged for authorised requests.
+
+# Map preflight error codes to (HTTP status, human message for progress stream).
+_INVITE_PREFLIGHT_ERRORS = {
+    "invite_required": (403, "Invite required"),
+    "invalid_invite": (403, "Invalid invite token"),
+    "invite_disabled": (403, "Invite disabled"),
+    "invite_password_required": (403, "Password required"),
+    "invite_expired": (403, "Invite expired"),
+    "invite_token_conflict": (400, "Conflicting invite tokens"),
+}
+
+
+def resolve_invite_token(request: Request, body_token: Optional[str]):
+    """Establish one unambiguous invite-token source (the request body).
+
+    The frontend always sends the token in the request body (multipart form field
+    or JSON field). To keep a single source of truth, if a token is *also* supplied
+    in the query string and disagrees with the body token we reject the request
+    rather than silently pick one.
+
+    Returns ``(token, error_code)`` where ``error_code`` is ``None`` when OK.
+    """
+    body = (body_token or "").strip() or None
+    try:
+        query = (request.query_params.get("invite_token") or "").strip() or None
+    except Exception:
+        query = None
+    if body and query and body != query:
+        return None, "invite_token_conflict"
+    return (body or query), None
+
+
+def invite_preflight(request: Request, invite_token: Optional[str]):
+    """Decide whether an upload may proceed, without mutating invite state.
+
+    Returns ``(token, error_code)``. ``error_code`` is ``None`` when the request
+    may continue; otherwise it is a key of ``_INVITE_PREFLIGHT_ERRORS``.
+
+    Rules:
+      * If PUBLIC_UPLOAD_PAGE_ENABLED is true, a missing token is allowed
+        (tokenless public upload); a supplied token is still validated.
+      * If PUBLIC_UPLOAD_PAGE_ENABLED is false, a valid active token is required.
+      * A supplied token is validated for existence, admin-disabled, password
+        authorisation and expiry. Claim/usage-exhaustion checks are intentionally
+        left to the real upload path.
+    """
+    token, conflict = resolve_invite_token(request, invite_token)
+    if conflict:
+        return None, conflict
+
+    if not token:
+        if SETTINGS.public_upload_page_enabled:
+            return None, None
+        return None, "invite_required"
+
+    try:
+        conn = sqlite3.connect(SETTINGS.state_db)
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT password_hash, expires_at, COALESCE(disabled,0) FROM invites WHERE token = ?",
+            (token,),
+        )
+        row = cur.fetchone()
+        conn.close()
+    except Exception as e:
+        logger.exception("Invite preflight lookup error: %s", e)
+        row = None
+    if not row:
+        return None, "invalid_invite"
+    password_hash, expires_at, disabled = row
+    try:
+        if int(disabled) == 1:
+            return token, "invite_disabled"
+    except Exception:
+        pass
+    if password_hash:
+        try:
+            ia = request.session.get("inviteAuth") or {}
+            if not ia.get(token):
+                return token, "invite_password_required"
+        except Exception:
+            return token, "invite_password_required"
+    if expires_at:
+        try:
+            if datetime.utcnow() > datetime.fromisoformat(expires_at):
+                return token, "invite_expired"
+        except Exception:
+            pass
+    return token, None
+
+
+async def _preflight_or_reject(request: Request, invite_token: Optional[str],
+                               session_id: Optional[str] = None,
+                               item_id: Optional[str] = None):
+    """Run :func:`invite_preflight`; return a JSONResponse to send on rejection.
+
+    Returns ``(token, response)``. When ``response`` is not None the caller must
+    return it immediately (before reading/writing any file data).
+    """
+    token, err = invite_preflight(request, invite_token)
+    if err is None:
+        return token, None
+    status_code, message = _INVITE_PREFLIGHT_ERRORS.get(err, (403, "Forbidden"))
+    if session_id and item_id:
+        try:
+            await send_progress(session_id, item_id, "error", 100, message)
+        except Exception:
+            pass
+    return token, JSONResponse({"error": err}, status_code=status_code)
+
+
 @app.post("/api/upload")
 async def api_upload(
     request: Request,
@@ -470,6 +588,11 @@ async def api_upload(
     fingerprint: Optional[str] = Form(None),
 ):
     """Receive a file, check duplicates, forward to Immich; stream progress via WS."""
+    # Gate BEFORE reading the uploaded file into memory (public-deployment hardening).
+    invite_token, rejection = await _preflight_or_reject(request, invite_token, session_id, item_id)
+    if rejection is not None:
+        return rejection
+
     raw = await file.read()
     size = len(raw)
     checksum = sha1_hex(raw)
@@ -725,6 +848,11 @@ async def api_upload_chunk_init(request: Request) -> JSONResponse:
     session_id = (data or {}).get("session_id")
     if not item_id or not session_id:
         return JSONResponse({"error": "missing_ids"}, status_code=400)
+    # Gate BEFORE creating any chunk directory / manifest on disk.
+    invite_token, rejection = await _preflight_or_reject(
+        request, (data or {}).get("invite_token"), session_id, item_id)
+    if rejection is not None:
+        return rejection
     d = _chunk_dir(session_id, item_id)
     try:
         os.makedirs(d, exist_ok=True)
@@ -733,7 +861,7 @@ async def api_upload_chunk_init(request: Request) -> JSONResponse:
             "name": (data or {}).get("name"),
             "size": (data or {}).get("size"),
             "last_modified": (data or {}).get("last_modified"),
-            "invite_token": (data or {}).get("invite_token"),
+            "invite_token": invite_token,
             "content_type": (data or {}).get("content_type") or "application/octet-stream",
             "created_at": datetime.utcnow().isoformat(),
         }
@@ -755,6 +883,10 @@ async def api_upload_chunk(
     chunk: UploadFile = Form(...),
 ) -> JSONResponse:
     """Receive a single chunk; write to disk under chunk directory."""
+    # Gate BEFORE reading the chunk body or writing anything to disk.
+    invite_token, rejection = await _preflight_or_reject(request, invite_token, session_id, item_id)
+    if rejection is not None:
+        return rejection
     d = _chunk_dir(session_id, item_id)
     try:
         os.makedirs(d, exist_ok=True)
@@ -798,6 +930,10 @@ async def api_upload_chunk_complete(request: Request) -> JSONResponse:
     content_type = (data or {}).get("content_type") or "application/octet-stream"
     if not item_id or not session_id:
         return JSONResponse({"error": "missing_ids"}, status_code=400)
+    # Gate BEFORE reading meta / assembling any chunk data from disk.
+    invite_token, rejection = await _preflight_or_reject(request, invite_token, session_id, item_id)
+    if rejection is not None:
+        return rejection
     d = _chunk_dir(session_id, item_id)
     meta_path = os.path.join(d, "meta.json")
     # Basic validation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,118 @@
+"""Pytest fixtures for invite-gating regression tests.
+
+Sets up an isolated temporary state DB and chunk directory before importing the
+app so the module-level ``db_init()`` / ``ensure_invites_table()`` calls target a
+throwaway location, then provides a TestClient plus helpers to seed invites and
+spy on the network / hashing paths that must NOT run on a rejected preflight.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta
+
+import pytest
+
+# Configure environment BEFORE importing the app so module-load side effects
+# (db_init/ensure_invites_table) use a temp DB and a deterministic secret.
+_TMP_DIR = tempfile.mkdtemp(prefix="invite_gating_tests_")
+os.environ["STATE_DB"] = os.path.join(_TMP_DIR, "state.db")
+os.environ["SESSION_SECRET"] = "test-secret-fixed"
+os.environ["PUBLIC_UPLOAD_PAGE_ENABLED"] = "false"
+os.environ.setdefault("IMMICH_BASE_URL", "http://immich.invalid/api")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app import app as appmod  # noqa: E402
+
+
+@pytest.fixture()
+def fresh_db(tmp_path):
+    """Point SETTINGS at a fresh DB + chunk root for each test and (re)create tables."""
+    db_path = str(tmp_path / "state.db")
+    chunk_root = str(tmp_path / "chunks")
+    os.makedirs(chunk_root, exist_ok=True)
+
+    appmod.SETTINGS.state_db = db_path
+    appmod.CHUNK_ROOT = chunk_root
+    # Default to the hardened (public disabled) posture; individual tests flip it.
+    appmod.SETTINGS.public_upload_page_enabled = False
+
+    appmod.db_init()
+    appmod.ensure_invites_table()
+    return {"db": db_path, "chunk_root": chunk_root}
+
+
+@pytest.fixture()
+def client(fresh_db):
+    return TestClient(appmod.app)
+
+
+@pytest.fixture()
+def spies(monkeypatch):
+    """Spy on the file-processing / network calls that must not run on rejection.
+
+    - ``sha1_hex`` is the first thing invoked after the uploaded file is read into
+      memory, so a zero call-count proves no file body was processed.
+    - ``requests.post`` is the outbound Immich upload; it must never fire on reject.
+    """
+    calls = {"sha1": 0, "post": 0}
+
+    real_sha1 = appmod.sha1_hex
+
+    def sha1_spy(data):
+        calls["sha1"] += 1
+        return real_sha1(data)
+
+    def post_spy(*args, **kwargs):  # pragma: no cover - should not run on reject
+        calls["post"] += 1
+
+        class _Resp:
+            status_code = 201
+
+            def json(self):
+                return {"id": "asset-xyz", "status": "created"}
+
+        return _Resp()
+
+    monkeypatch.setattr(appmod, "sha1_hex", sha1_spy)
+    monkeypatch.setattr(appmod.requests, "post", post_spy)
+    # Never reach a real Immich for bulk-check either.
+    monkeypatch.setattr(appmod, "immich_bulk_check", lambda checks: {})
+    return calls
+
+
+# ---------- helpers ----------
+
+def seed_invite(db_path, token, *, max_uses=-1, expires_at=None,
+                password_hash=None, disabled=0, used_count=0, claimed=0):
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO invites (token, album_id, album_name, max_uses, used_count, "
+        "expires_at, password_hash, disabled, claimed) VALUES (?,?,?,?,?,?,?,?,?)",
+        (token, None, None, max_uses, used_count, expires_at, password_hash, disabled, claimed),
+    )
+    conn.commit()
+    conn.close()
+
+
+def invite_row(db_path, token):
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT used_count, COALESCE(claimed,0) FROM invites WHERE token = ?",
+        (token,),
+    )
+    row = cur.fetchone()
+    conn.close()
+    return {"used_count": row[0], "claimed": row[1]} if row else None
+
+
+def past_iso():
+    return (datetime.utcnow() - timedelta(days=1)).isoformat()
+
+
+def future_iso():
+    return (datetime.utcnow() + timedelta(days=1)).isoformat()

--- a/tests/test_invite_gating.py
+++ b/tests/test_invite_gating.py
@@ -1,0 +1,228 @@
+"""Regression tests for invite-gated uploads (public deployment hardening).
+
+When PUBLIC_UPLOAD_PAGE_ENABLED is false, the upload API must reject requests
+that lack a valid, active invite *before* reading/assembling/writing any file
+data. Valid tokens and the public-enabled tokenless mode keep working, and the
+preflight must not claim invites or bump usage.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+
+from conftest import (
+    seed_invite,
+    invite_row,
+    past_iso,
+    future_iso,
+)
+
+
+def _upload(client, *, token=None, extra=None, filename="pic.jpg"):
+    data = {"item_id": "item-1", "session_id": "sess-1", "fingerprint": "fp"}
+    if token is not None:
+        data["invite_token"] = token
+    if extra:
+        data.update(extra)
+    files = {"file": (filename, io.BytesIO(b"hello-bytes"), "image/jpeg")}
+    return client.post("/api/upload", data=data, files=files)
+
+
+def _chunk_dir(chunk_root, session_id="sess-1", item_id="item-1"):
+    return os.path.join(chunk_root, session_id, item_id)
+
+
+# --------- /api/upload preflight rejections (public disabled) ---------
+
+def test_upload_rejects_missing_token(client, spies):
+    r = _upload(client, token=None)
+    assert r.status_code == 403
+    assert spies["sha1"] == 0
+    assert spies["post"] == 0
+
+
+def test_upload_rejects_empty_token(client, spies):
+    r = _upload(client, token="")
+    assert r.status_code == 403
+    assert spies["sha1"] == 0
+    assert spies["post"] == 0
+
+
+def test_upload_rejects_invalid_token(client, spies):
+    r = _upload(client, token="does-not-exist")
+    assert r.status_code == 403
+    assert r.json().get("error") == "invalid_invite"
+    assert spies["sha1"] == 0
+    assert spies["post"] == 0
+
+
+def test_upload_rejects_disabled_invite(client, fresh_db, spies):
+    seed_invite(fresh_db["db"], "tok-disabled", disabled=1)
+    r = _upload(client, token="tok-disabled")
+    assert r.status_code == 403
+    assert r.json().get("error") == "invite_disabled"
+    assert spies["sha1"] == 0
+    assert spies["post"] == 0
+
+
+def test_upload_rejects_expired_invite(client, fresh_db, spies):
+    seed_invite(fresh_db["db"], "tok-expired", expires_at=past_iso())
+    r = _upload(client, token="tok-expired")
+    assert r.status_code == 403
+    assert r.json().get("error") == "invite_expired"
+    assert spies["sha1"] == 0
+    assert spies["post"] == 0
+
+
+def test_upload_rejects_password_protected_unauthorized(client, fresh_db, spies):
+    seed_invite(fresh_db["db"], "tok-pw", password_hash="somehash")
+    r = _upload(client, token="tok-pw")
+    assert r.status_code == 403
+    assert r.json().get("error") == "invite_password_required"
+    assert spies["sha1"] == 0
+    assert spies["post"] == 0
+
+
+def test_upload_preflight_does_not_claim_or_increment(client, fresh_db, spies):
+    # A one-time, password-protected invite that gets rejected must remain pristine.
+    seed_invite(fresh_db["db"], "tok-pw1", max_uses=1, password_hash="somehash")
+    r = _upload(client, token="tok-pw1")
+    assert r.status_code == 403
+    row = invite_row(fresh_db["db"], "tok-pw1")
+    assert row == {"used_count": 0, "claimed": 0}
+
+
+# --------- /api/upload happy paths ---------
+
+def test_upload_valid_token_proceeds_and_increments(client, fresh_db, spies):
+    seed_invite(fresh_db["db"], "tok-ok", max_uses=-1)
+    r = _upload(client, token="tok-ok")
+    assert r.status_code == 200
+    assert spies["sha1"] >= 1
+    assert spies["post"] == 1
+    # Usage semantics stay in the real upload path.
+    assert invite_row(fresh_db["db"], "tok-ok")["used_count"] == 1
+
+
+def test_upload_public_enabled_tokenless_ok(client, fresh_db, spies):
+    import app.app as appmod
+    appmod.SETTINGS.public_upload_page_enabled = True
+    try:
+        r = _upload(client, token=None)
+        assert r.status_code == 200
+        assert spies["post"] == 1
+    finally:
+        appmod.SETTINGS.public_upload_page_enabled = False
+
+
+# --------- token source ambiguity (AC #6) ---------
+
+def test_upload_rejects_token_conflict(client, fresh_db, spies):
+    seed_invite(fresh_db["db"], "tok-a", max_uses=-1)
+    # Same token in form body and query string but different values -> conflict.
+    r = client.post(
+        "/api/upload?invite_token=tok-b",
+        data={"item_id": "i", "session_id": "s", "invite_token": "tok-a"},
+        files={"file": ("p.jpg", io.BytesIO(b"x"), "image/jpeg")},
+    )
+    assert r.status_code == 400
+    assert r.json().get("error") == "invite_token_conflict"
+    assert spies["sha1"] == 0
+    assert spies["post"] == 0
+
+
+# --------- /api/upload/chunk/init ---------
+
+def test_chunk_init_rejects_missing_token(client, fresh_db, spies):
+    r = client.post("/api/upload/chunk/init", json={
+        "item_id": "item-1", "session_id": "sess-1",
+        "name": "f.bin", "size": 10,
+    })
+    assert r.status_code == 403
+    # No chunk directory / manifest should have been created.
+    assert not os.path.exists(_chunk_dir(fresh_db["chunk_root"]))
+
+
+def test_chunk_init_valid_token_ok(client, fresh_db, spies):
+    seed_invite(fresh_db["db"], "tok-ok", max_uses=-1)
+    r = client.post("/api/upload/chunk/init", json={
+        "item_id": "item-1", "session_id": "sess-1",
+        "name": "f.bin", "size": 10, "invite_token": "tok-ok",
+    })
+    assert r.status_code == 200
+    assert os.path.exists(os.path.join(_chunk_dir(fresh_db["chunk_root"]), "meta.json"))
+
+
+def test_chunk_init_public_enabled_tokenless_ok(client, fresh_db, spies):
+    import app.app as appmod
+    appmod.SETTINGS.public_upload_page_enabled = True
+    try:
+        r = client.post("/api/upload/chunk/init", json={
+            "item_id": "item-1", "session_id": "sess-1", "name": "f.bin", "size": 10,
+        })
+        assert r.status_code == 200
+    finally:
+        appmod.SETTINGS.public_upload_page_enabled = False
+
+
+# --------- /api/upload/chunk (part write) ---------
+
+def test_chunk_part_rejects_missing_token_and_writes_nothing(client, fresh_db, spies):
+    r = client.post("/api/upload/chunk", data={
+        "item_id": "item-1", "session_id": "sess-1",
+        "chunk_index": "0", "total_chunks": "1",
+    }, files={"chunk": ("f.part0", io.BytesIO(b"chunkdata"), "application/octet-stream")})
+    assert r.status_code == 403
+    d = _chunk_dir(fresh_db["chunk_root"])
+    # Nothing written to disk.
+    assert not os.path.exists(os.path.join(d, "part_000000"))
+
+
+def test_chunk_part_valid_token_writes(client, fresh_db, spies):
+    seed_invite(fresh_db["db"], "tok-ok", max_uses=-1)
+    r = client.post("/api/upload/chunk", data={
+        "item_id": "item-1", "session_id": "sess-1",
+        "chunk_index": "0", "total_chunks": "1", "invite_token": "tok-ok",
+    }, files={"chunk": ("f.part0", io.BytesIO(b"chunkdata"), "application/octet-stream")})
+    assert r.status_code == 200
+    d = _chunk_dir(fresh_db["chunk_root"])
+    assert os.path.exists(os.path.join(d, "part_000000"))
+
+
+# --------- /api/upload/chunk/complete ---------
+
+def _prime_chunk_dir(chunk_root, total_chunks=1, payload=b"assembled"):
+    d = _chunk_dir(chunk_root)
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, "meta.json"), "w", encoding="utf-8") as f:
+        json.dump({"name": "f.bin", "total_chunks": total_chunks,
+                   "content_type": "application/octet-stream"}, f)
+    for i in range(total_chunks):
+        with open(os.path.join(d, f"part_{i:06d}"), "wb") as f:
+            f.write(payload)
+    return d
+
+
+def test_chunk_complete_rejects_before_assemble(client, fresh_db, spies):
+    d = _prime_chunk_dir(fresh_db["chunk_root"])
+    r = client.post("/api/upload/chunk/complete", json={
+        "item_id": "item-1", "session_id": "sess-1", "name": "f.bin", "total_chunks": 1,
+    })
+    assert r.status_code == 403
+    # Parts must NOT be read/assembled/cleaned up, and no Immich upload attempted.
+    assert os.path.exists(os.path.join(d, "part_000000"))
+    assert spies["sha1"] == 0
+    assert spies["post"] == 0
+
+
+def test_chunk_complete_valid_token_proceeds(client, fresh_db, spies):
+    seed_invite(fresh_db["db"], "tok-ok", max_uses=-1)
+    _prime_chunk_dir(fresh_db["chunk_root"])
+    r = client.post("/api/upload/chunk/complete", json={
+        "item_id": "item-1", "session_id": "sess-1", "name": "f.bin",
+        "total_chunks": 1, "invite_token": "tok-ok",
+    })
+    assert r.status_code == 200
+    assert spies["post"] == 1
+    assert invite_row(fresh_db["db"], "tok-ok")["used_count"] == 1


### PR DESCRIPTION
## Summary

- require a valid, active invite for direct and chunked upload endpoints when `PUBLIC_UPLOAD_PAGE_ENABLED=false`
- reject missing, invalid, disabled, expired, and password-protected-but-unauthorized invites before application-level file processing
- reject conflicting body/query invite tokens instead of silently choosing one
- preserve tokenless uploads when the public uploader is explicitly enabled
- preserve existing claim and usage-count semantics for authorized uploads
- add 17 focused regression tests for rejection, compatibility, and no-preflight-mutation behavior

## Why

On current `master`, `PUBLIC_UPLOAD_PAGE_ENABLED=false` only redirects the `/` landing page to login. The upload handlers still accept an optional `invite_token`; when it is omitted, they skip invite validation and forward the upload using the server-side Immich API key.

That leaves the upload API callable without an invite even though the public uploader is disabled. It also allows chunk directories/files to be created before invite validation. This contradicts the intended invite-only behavior discussed in #5.

This change adds a read-only invite preflight before the existing upload logic. The preflight does not claim links or increment usage; those mutations remain in the established successful-upload path.

## Verification

- `python -m pytest tests/ -q` — **17 passed**
- `python -m compileall -q app tests` — passed
- `docker build --pull=false -t local/immich-drop:pr-7fe4100 .` — passed
- `git diff origin/master...HEAD --check` — passed

## Compatibility

- tokenless uploads remain available when `PUBLIC_UPLOAD_PAGE_ENABLED=true`
- valid invite uploads retain the existing one-time/multi-use behavior
- no frontend change is required; it already sends the invite token in the request body

Follow-up to #5.
